### PR TITLE
[DO NOT MERGE] Just shows the diff between madsim patch and sqlx v0.7.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,6 +322,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.52",
+]
+
+[[package]]
 name = "async-task"
 version = "4.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -495,6 +517,15 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits",
+]
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -970,7 +1001,7 @@ dependencies = [
  "bitflags 1.3.2",
  "crossterm_winapi",
  "libc",
- "mio",
+ "mio 0.8.11",
  "parking_lot",
  "signal-hook",
  "signal-hook-mio",
@@ -1004,12 +1035,36 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
+dependencies = [
+ "darling_core 0.14.4",
+ "darling_macro 0.14.4",
+]
+
+[[package]]
+name = "darling"
 version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54e36fcd13ed84ffdfda6f5be89b31287cbb80c439841fe69e04841435464391"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.8",
+ "darling_macro 0.20.8",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.10.0",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1028,11 +1083,22 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
+dependencies = [
+ "darling_core 0.14.4",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
 dependencies = [
- "darling_core",
+ "darling_core 0.20.8",
  "quote",
  "syn 2.0.52",
 ]
@@ -1114,6 +1180,12 @@ name = "downcast"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "either"
@@ -1948,6 +2020,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "madsim"
+version = "0.2.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3c97f34bb19cf6a435a4da2187e90acc6bc59faa730e493b28b6d33e1bb9ccb"
+dependencies = [
+ "ahash 0.8.11",
+ "async-channel 2.2.0",
+ "async-stream",
+ "async-task",
+ "bincode",
+ "bytes",
+ "downcast-rs",
+ "futures-util",
+ "lazy_static",
+ "libc",
+ "madsim-macros",
+ "naive-timer",
+ "panic-message",
+ "rand",
+ "rand_xoshiro",
+ "rustversion",
+ "serde",
+ "spin 0.9.8",
+ "tokio",
+ "tokio-util",
+ "toml",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "madsim-macros"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3d248e97b1a48826a12c3828d921e8548e714394bf17274dd0a93910dc946e1"
+dependencies = [
+ "darling 0.14.4",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "madsim-tokio"
+version = "0.2.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d3eb2acc57c82d21d699119b859e2df70a91dbdb84734885a1e72be83bdecb5"
+dependencies = [
+ "madsim",
+ "spin 0.9.8",
+ "tokio",
+]
+
+[[package]]
 name = "matchit"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2012,6 +2138,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
+dependencies = [
+ "hermit-abi 0.3.9",
+ "libc",
+ "wasi",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "mockall"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2037,6 +2175,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "naive-timer"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "034a0ad7deebf0c2abcf2435950a6666c3c15ea9d8fad0c0f48efa8a7f843fed"
 
 [[package]]
 name = "native-tls"
@@ -2093,6 +2237,16 @@ name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
 
 [[package]]
 name = "num-bigint"
@@ -2156,16 +2310,6 @@ checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
 dependencies = [
  "autocfg",
  "libm",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi 0.3.9",
- "libc",
 ]
 
 [[package]]
@@ -2242,6 +2386,18 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "panic-message"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384e52fd8fbd4cbe3c317e8216260c21a0f9134de108cea8a4dd4e7e152c472d"
 
 [[package]]
 name = "parking"
@@ -2491,7 +2647,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.21.1",
 ]
 
 [[package]]
@@ -2842,6 +2998,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
+
+[[package]]
 name = "rustyline"
 version = "9.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2975,6 +3137,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3008,7 +3179,7 @@ version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "881b6f881b17d13214e5d494c939ebab463d01264ce1811e9d4ac3a882e7695f"
 dependencies = [
- "darling",
+ "darling 0.20.8",
  "proc-macro2",
  "quote",
  "syn 2.0.52",
@@ -3037,6 +3208,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "signal-hook"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3053,7 +3233,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
 dependencies = [
  "libc",
- "mio",
+ "mio 0.8.11",
  "signal-hook",
 ]
 
@@ -3200,12 +3380,12 @@ dependencies = [
  "filetime",
  "futures",
  "glob",
+ "madsim-tokio",
  "openssl",
  "promptly",
  "serde",
  "serde_json",
  "sqlx",
- "tokio",
  "url",
 ]
 
@@ -3240,6 +3420,7 @@ dependencies = [
  "ipnetwork",
  "log",
  "mac_address",
+ "madsim-tokio",
  "memchr",
  "native-tls",
  "num-bigint",
@@ -3259,7 +3440,6 @@ dependencies = [
  "sqlx",
  "thiserror",
  "time",
- "tokio",
  "tokio-stream",
  "tracing",
  "url",
@@ -3273,9 +3453,9 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "futures",
+ "madsim-tokio",
  "sqlx",
  "structopt",
- "tokio",
 ]
 
 [[package]]
@@ -3286,6 +3466,7 @@ dependencies = [
  "argon2",
  "axum",
  "dotenvy",
+ "madsim-tokio",
  "once_cell",
  "rand",
  "regex",
@@ -3295,7 +3476,6 @@ dependencies = [
  "sqlx",
  "thiserror",
  "time",
- "tokio",
  "tower",
  "tracing",
  "uuid",
@@ -3308,8 +3488,8 @@ version = "0.1.0"
 dependencies = [
  "crossterm",
  "futures",
+ "madsim-tokio",
  "sqlx",
- "tokio",
  "tui",
  "unicode-width",
 ]
@@ -3320,8 +3500,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "dotenvy",
+ "madsim-tokio",
  "sqlx",
- "tokio",
 ]
 
 [[package]]
@@ -3331,11 +3511,11 @@ dependencies = [
  "anyhow",
  "dotenvy",
  "futures",
+ "madsim-tokio",
  "serde",
  "serde_json",
  "sqlx",
  "structopt",
- "tokio",
 ]
 
 [[package]]
@@ -3343,8 +3523,8 @@ name = "sqlx-example-postgres-listen"
 version = "0.1.0"
 dependencies = [
  "futures",
+ "madsim-tokio",
  "sqlx",
- "tokio",
 ]
 
 [[package]]
@@ -3355,10 +3535,10 @@ dependencies = [
  "async-trait",
  "dotenvy",
  "futures",
+ "madsim-tokio",
  "mockall",
  "sqlx",
  "structopt",
- "tokio",
 ]
 
 [[package]]
@@ -3368,9 +3548,9 @@ dependencies = [
  "anyhow",
  "dotenvy",
  "futures",
+ "madsim-tokio",
  "sqlx",
  "structopt",
- "tokio",
 ]
 
 [[package]]
@@ -3378,8 +3558,8 @@ name = "sqlx-example-postgres-transaction"
 version = "0.1.0"
 dependencies = [
  "futures",
+ "madsim-tokio",
  "sqlx",
- "tokio",
 ]
 
 [[package]]
@@ -3388,9 +3568,9 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "futures",
+ "madsim-tokio",
  "sqlx",
  "structopt",
- "tokio",
 ]
 
 [[package]]
@@ -3413,6 +3593,7 @@ dependencies = [
  "either",
  "heck 0.4.1",
  "hex",
+ "madsim-tokio",
  "once_cell",
  "proc-macro2",
  "quote",
@@ -3425,7 +3606,6 @@ dependencies = [
  "sqlx-sqlite",
  "syn 1.0.109",
  "tempfile",
- "tokio",
  "url",
 ]
 
@@ -3523,16 +3703,17 @@ dependencies = [
 name = "sqlx-sqlite"
 version = "0.7.4"
 dependencies = [
+ "async-channel 2.2.0",
  "atoi",
  "chrono",
  "flume",
  "futures-channel",
  "futures-core",
- "futures-executor",
  "futures-intrusive",
  "futures-util",
  "libsqlite3-sys",
  "log",
+ "madsim-tokio",
  "percent-encoding",
  "regex",
  "serde",
@@ -3553,8 +3734,8 @@ dependencies = [
  "async-std",
  "dotenvy",
  "env_logger",
+ "madsim-tokio",
  "sqlx",
- "tokio",
 ]
 
 [[package]]
@@ -3725,6 +3906,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "time"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3782,28 +3973,27 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.36.0"
+version = "1.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
+checksum = "145f3413504347a2be84393cc8a7d2fb4d863b375909ea59f2158261aa258bbb"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
- "mio",
- "num_cpus",
+ "mio 1.0.2",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2 0.5.6",
  "tokio-macros",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.2.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3822,10 +4012,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9dd1545e8208b4a5af1aa9bbd0b4cf7e9ea08fabc5d0a5c67fcaafa17433aa3"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit 0.22.12",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_edit"
@@ -3835,7 +4053,20 @@ checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
  "indexmap 2.2.5",
  "toml_datetime",
- "winnow",
+ "winnow 0.5.40",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3328d4f68a705b2a4498da1d580585d39a6510f98318a2cec3018a7ec61ddef"
+dependencies = [
+ "indexmap 2.2.5",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow 0.6.20",
 ]
 
 [[package]]
@@ -3915,6 +4146,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -4075,6 +4332,12 @@ dependencies = [
  "proc-macro2",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "value-bag"
@@ -4415,6 +4678,15 @@ name = "winnow"
 version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,8 +145,9 @@ dotenvy = { version = "0.15.0", default-features = false }
 version = "1.12"
 
 [workspace.dependencies.tokio]
-version = "1"
-features = ["time", "net", "sync", "fs", "io-util", "rt"]
+version = "0.2.30"
+package = "madsim-tokio"
+features = ["time", "net", "sync", "fs", "io-util", "rt", "macros", "rt-multi-thread"]
 default-features = false
 
 [dependencies]

--- a/examples/mysql/todos/Cargo.toml
+++ b/examples/mysql/todos/Cargo.toml
@@ -9,4 +9,4 @@ anyhow = "1.0"
 futures = "0.3"
 sqlx = { path = "../../../", features = [ "mysql", "runtime-tokio-native-tls" ] }
 structopt = "0.3"
-tokio = { version = "1.20.0", features = ["rt", "macros"]}
+tokio = { workspace = true, optional = true }

--- a/examples/postgres/axum-social-with-tests/Cargo.toml
+++ b/examples/postgres/axum-social-with-tests/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 # Primary crates
 axum = { version = "0.5.13", features = ["macros"] }
 sqlx = { path = "../../../", features = ["runtime-tokio-rustls", "postgres", "time", "uuid"] }
-tokio = { version = "1.20.1", features = ["rt-multi-thread", "macros"] }
+tokio = { workspace = true, optional = true }
 
 # Important secondary crates
 argon2 = "0.4.1"

--- a/examples/postgres/chat/Cargo.toml
+++ b/examples/postgres/chat/Cargo.toml
@@ -7,7 +7,7 @@ workspace = "../../../"
 [dependencies]
 sqlx = { path = "../../../", features = [ "postgres", "runtime-tokio-native-tls" ] }
 futures = "0.3.1"
-tokio = { version = "1.20.0", features = [ "rt-multi-thread", "macros" ] }
+tokio = { workspace = true, optional = true }
 tui = "0.19.0"
 crossterm = "0.25"
 unicode-width = "0.1"

--- a/examples/postgres/files/Cargo.toml
+++ b/examples/postgres/files/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0"
 sqlx = { path = "../../../", features = ["postgres", "runtime-tokio-native-tls"] }
-tokio = { version = "1.20.0", features = ["rt", "macros"]}
+tokio = { workspace = true, optional = true }
 dotenvy = "0.15.0"

--- a/examples/postgres/json/Cargo.toml
+++ b/examples/postgres/json/Cargo.toml
@@ -12,4 +12,4 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sqlx = { path = "../../../", features = ["runtime-tokio", "postgres", "json"] }
 structopt = "0.3"
-tokio = { version = "1.20.0", features = ["rt", "macros"]}
+tokio = { workspace = true, optional = true }

--- a/examples/postgres/listen/Cargo.toml
+++ b/examples/postgres/listen/Cargo.toml
@@ -7,4 +7,4 @@ workspace = "../../../"
 [dependencies]
 sqlx = { path = "../../../", features = [ "runtime-tokio", "postgres" ] }
 futures = "0.3.1"
-tokio = { version = "1.20.0", features = ["rt-multi-thread", "macros", "time"]}
+tokio = { workspace = true, optional = true }

--- a/examples/postgres/mockable-todos/Cargo.toml
+++ b/examples/postgres/mockable-todos/Cargo.toml
@@ -9,7 +9,7 @@ anyhow = "1.0"
 futures = "0.3"
 sqlx = { path = "../../../", features = ["postgres", "runtime-tokio-native-tls"] }
 structopt = "0.3"
-tokio = { version = "1.20.0", features = ["rt", "macros"]}
+tokio = { workspace = true, optional = true }
 dotenvy = "0.15.0"
 async-trait = "0.1.41"
 mockall = "0.11"

--- a/examples/postgres/todos/Cargo.toml
+++ b/examples/postgres/todos/Cargo.toml
@@ -9,5 +9,5 @@ anyhow = "1.0"
 futures = "0.3"
 sqlx = { path = "../../../", features = ["postgres", "runtime-tokio-native-tls"] }
 structopt = "0.3"
-tokio = { version = "1.20.0", features = ["rt", "macros"]}
+tokio = { workspace = true, optional = true }
 dotenvy = "0.15.0"

--- a/examples/postgres/transaction/Cargo.toml
+++ b/examples/postgres/transaction/Cargo.toml
@@ -7,4 +7,4 @@ workspace = "../../../"
 [dependencies]
 sqlx = { path = "../../../", features = [ "postgres", "runtime-tokio-native-tls" ] }
 futures = "0.3.1"
-tokio = { version = "1.20.0", features = ["rt-multi-thread", "macros"]}
+tokio = { workspace = true, optional = true }

--- a/examples/sqlite/todos/Cargo.toml
+++ b/examples/sqlite/todos/Cargo.toml
@@ -9,4 +9,4 @@ anyhow = "1.0"
 futures = "0.3"
 sqlx = { path = "../../../", features = ["sqlite", "runtime-tokio-native-tls"] }
 structopt = "0.3"
-tokio = { version = "1.20.0", features = ["rt", "macros"]}
+tokio = { workspace = true, optional = true }

--- a/sqlx-cli/Cargo.toml
+++ b/sqlx-cli/Cargo.toml
@@ -26,7 +26,7 @@ path = "src/bin/cargo-sqlx.rs"
 
 [dependencies]
 dotenvy = "0.15.0"
-tokio = { version = "1.15.0", features = ["macros", "rt", "rt-multi-thread"] }
+tokio = { workspace = true, optional = true }
 sqlx = { workspace = true, default-features = false, features = [
     "runtime-tokio",
     "migrate",

--- a/sqlx-core/Cargo.toml
+++ b/sqlx-core/Cargo.toml
@@ -91,4 +91,3 @@ event-listener = "2.5.2"
 
 [dev-dependencies]
 sqlx = { workspace = true, features = ["postgres", "sqlite", "mysql", "migrate", "macros", "time", "uuid"] }
-tokio = { version = "1", features = ["rt"] }

--- a/sqlx-core/src/net/socket/mod.rs
+++ b/sqlx-core/src/net/socket/mod.rs
@@ -13,7 +13,7 @@ use crate::io::ReadBuf;
 
 mod buffered;
 
-pub trait Socket: Send + Sync + Unpin + 'static {
+pub trait Socket: Send + Unpin + 'static {
     fn try_read(&mut self, buf: &mut dyn ReadBuf) -> io::Result<usize>;
 
     fn try_write(&mut self, buf: &[u8]) -> io::Result<usize>;

--- a/sqlx-sqlite/Cargo.toml
+++ b/sqlx-sqlite/Cargo.toml
@@ -23,7 +23,6 @@ regexp = ["dep:regex"]
 futures-core = { version = "0.3.19", default-features = false }
 futures-channel = { version = "0.3.19", default-features = false, features = ["sink", "alloc", "std"] }
 # used by the SQLite worker thread to block on the async mutex that locks the database handle
-futures-executor = { version = "0.3.19" }
 futures-intrusive = "0.5.0"
 futures-util = { version = "0.3.19", default-features = false, features = ["alloc", "sink"] }
 
@@ -44,6 +43,8 @@ tracing = { version = "0.1.37", features = ["log"] }
 serde = { version = "1.0.145", features = ["derive"], optional = true }
 regex = { version = "1.5.5", optional = true }
 urlencoding = "2.1.3"
+tokio = { workspace = true }
+async-channel = "2.2.0"
 
 [dependencies.libsqlite3-sys]
 version = "0.27.0"

--- a/sqlx-sqlite/src/connection/worker.rs
+++ b/sqlx-sqlite/src/connection/worker.rs
@@ -115,7 +115,7 @@ impl ConnectionWorker {
                 // would rollback an already completed transaction.
                 let mut ignore_next_start_rollback = false;
 
-                for (cmd, span) in command_rx {
+                while let Ok((cmd, span)) = command_rx.recv_async().await {
                     let _guard = span.enter();
                     match cmd {
                         Command::Prepare { query, tx } => {

--- a/sqlx-sqlite/src/connection/worker.rs
+++ b/sqlx-sqlite/src/connection/worker.rs
@@ -79,7 +79,7 @@ impl ConnectionWorker {
     pub(crate) async fn establish(params: EstablishParams) -> Result<Self, Error> {
         let (establish_tx, establish_rx) = oneshot::channel();
 
-            tokio::spawn(async {
+            tokio::spawn(async move {
                 let (command_tx, command_rx) = flume::bounded(params.command_channel_size);
 
                 let conn = match params.establish() {
@@ -164,7 +164,7 @@ impl ConnectionWorker {
                                     });
                             let res_ok = res.is_ok();
 
-                            if tx.blocking_send(res).is_err() && res_ok {
+                            if tx.send(res).await.is_err() && res_ok {
                                 // The BEGIN was processed but not acknowledged. This means no
                                 // `Transaction` was created and so there is no way to commit /
                                 // rollback this transaction. We need to roll it back
@@ -198,7 +198,7 @@ impl ConnectionWorker {
                             };
                             let res_ok = res.is_ok();
 
-                            if tx.blocking_send(res).is_err() && res_ok {
+                            if tx.send(res).await.is_err() && res_ok {
                                 // The COMMIT was processed but not acknowledged. This means that
                                 // the `Transaction` doesn't know it was committed and will try to
                                 // rollback on drop. We need to ignore that rollback.
@@ -226,7 +226,7 @@ impl ConnectionWorker {
                             let res_ok = res.is_ok();
 
                             if let Some(tx) = tx {
-                                if tx.blocking_send(res).is_err() && res_ok {
+                                if tx.send(res).await.is_err() && res_ok {
                                     // The ROLLBACK was processed but not acknowledged. This means
                                     // that the `Transaction` doesn't know it was rolled back and
                                     // will try to rollback again on drop. We need to ignore that
@@ -242,7 +242,7 @@ impl ConnectionWorker {
                         }
                         Command::UnlockDb => {
                             drop(conn);
-                            conn = futures_executor::block_on(shared.conn.lock());
+                            conn = shared.conn.lock().await;
                         }
                         Command::Ping { tx } => {
                             tx.send(()).ok();
@@ -257,7 +257,7 @@ impl ConnectionWorker {
                         }
                     }
                 }
-            })?;
+            });
 
         establish_rx.await.map_err(|_| Error::WorkerCrashed)?
     }
@@ -380,12 +380,13 @@ impl ConnectionWorker {
     pub(crate) fn shutdown(&mut self) -> impl Future<Output = Result<(), Error>> {
         let (tx, rx) = oneshot::channel();
 
-        let send_res = self
-            .command_tx
-            .send((Command::Shutdown { tx }, Span::current()))
-            .map_err(|_| Error::WorkerCrashed);
+        let command_tx = self.command_tx.clone();
 
         async move {
+            let send_res = command_tx
+                .send_async((Command::Shutdown { tx }, Span::current()))
+                .await
+                .map_err(|_| Error::WorkerCrashed);
             send_res?;
 
             // wait for the response
@@ -442,10 +443,6 @@ mod rendezvous_oneshot {
             let (ack_tx, ack_rx) = oneshot::channel();
             self.inner.send((value, ack_tx)).map_err(|_| Canceled)?;
             ack_rx.await
-        }
-
-        pub fn blocking_send(self, value: T) -> Result<(), Canceled> {
-            futures_executor::block_on(self.send(value))
         }
     }
 

--- a/sqlx-sqlite/src/connection/worker.rs
+++ b/sqlx-sqlite/src/connection/worker.rs
@@ -2,7 +2,6 @@ use std::borrow::Cow;
 use std::future::Future;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
-use std::thread;
 
 use futures_intrusive::sync::{Mutex, MutexGuard};
 
@@ -80,9 +79,7 @@ impl ConnectionWorker {
     pub(crate) async fn establish(params: EstablishParams) -> Result<Self, Error> {
         let (establish_tx, establish_rx) = oneshot::channel();
 
-        thread::Builder::new()
-            .name(params.thread_name.clone())
-            .spawn(move || {
+            tokio::spawn(async {
                 let (command_tx, command_rx) = flume::bounded(params.command_channel_size);
 
                 let conn = match params.establish() {

--- a/sqlx-test/Cargo.toml
+++ b/sqlx-test/Cargo.toml
@@ -9,5 +9,5 @@ sqlx = { default-features = false, path = ".." }
 env_logger = "0.11"
 dotenvy = "0.15.0"
 anyhow = "1.0.26"
-async-std = { version = "1.8.0", features = [ "attributes" ] }
-tokio = { version = "1.0.1", features = [ "full" ] }
+async-std = { version = "1.8.0", features = ["attributes"] }
+tokio = { workspace = true, optional = true }


### PR DESCRIPTION
### Does your PR solve an issue?

We rebase the commits atop of v0.7.4, a commit tagged in the main branch of sqlx.

We migrate the changes from https://github.com/madsim-rs/sqlx/pull/1/files over to this branch (`kwannoel/madsim-v2`).
Some changes were unnecessary, e.g. changing functions to async, without any internal await points. Those are left out.

Notable changes:
1. We make sqlx-sqlite connection worker poll events asynchronously. Otherwise our madsim runtime will be blocked.
2. We make sqlx-sqlite worker use a tokio thread (so it can use madsim) instead of system thread, to avoid non-determinism.
3. We have each commit as modular as possible, so it's easier to rebase on `sqlx:main` and fix conflicts.

The workflow for patching some tagged version will just be to rebase on that tag, e.g. v0.8.1. Then release the patched branch by pushing the changes to the branch `madsim-vX.Y.Z`.

Subsequently, once this PR is approved, we can create a new `madsim-v0.7.4` branch for it.